### PR TITLE
Make CLI versions and upgrades predictable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and verify distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Verify tag matches package version
+        env:
+          PYTHONPATH: src
+        run: >-
+          python -c "import os; from smartmoney_cub_harness import __version__;
+          expected = f'v{__version__}'; actual = os.environ['GITHUB_REF_NAME'];
+          assert actual == expected, f'tag {actual!r} does not match {expected!r}'"
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Verify built wheel installs
+        run: |
+          python -m pip install dist/*.whl
+          smcub --version
+          smcub doctor
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  pypi-publish:
+    name: Publish distributions to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: pypi-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create release and attach distributions
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}" dist/*
+          --verify-tag --generate-notes --title "${GITHUB_REF_NAME}"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+.venv/
 .coverage
 htmlcov/
 dist/

--- a/README.md
+++ b/README.md
@@ -48,6 +48,37 @@
 | OpenCode / OpenClaw | `帮我用这个仓库做一次只读复盘演示：运行 smcub doctor，再运行 smcub loop --preset toy --agent-trigger "自进化"。` |
 | CLI 直用 | `git clone https://github.com/myc0576/smartmoney-cub-harness.git && cd smartmoney-cub-harness && pip install -e ".[dev]" && smcub loop --preset toy --agent-trigger "自进化"` |
 
+### 隔离安装与版本确认
+
+不要把开发版本直接装进全局 Python。Windows 推荐使用项目内虚拟环境：
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -e ".[dev]"
+.\.venv\Scripts\smcub.exe --version
+.\.venv\Scripts\smcub.exe doctor
+```
+
+macOS / Linux：
+
+```bash
+python -m venv .venv
+./.venv/bin/python -m pip install -e ".[dev]"
+./.venv/bin/smcub --version
+./.venv/bin/smcub doctor
+```
+
+如果电脑里安装过多个 Python，直接输入 `smcub` 可能命中另一个环境中的旧版本。安装后请运行 `smcub --version` 和 `smcub doctor`；`doctor` 会以不暴露本地路径的方式提示启动器冲突。
+
+正式发布到 PyPI 后，普通 CLI 用户推荐使用 pipx，让命令拥有独立环境：
+
+```bash
+pipx install smartmoney-cub-harness
+pipx upgrade smartmoney-cub-harness
+```
+
+现有安装不会自动同步。Git editable、pip、pipx 和源码压缩包用户的升级方式，以及 SemVer、Git tag、GitHub Release、PyPI 发布顺序，见 [版本与升级政策](docs/versioning.md)。
+
 装好后最常用的安全命令：
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,6 +48,37 @@
 | OpenCode / OpenClaw | `帮我用这个仓库做一次只读复盘演示：运行 smcub doctor，再运行 smcub loop --preset toy --agent-trigger "自进化"。` |
 | CLI 直用 | `git clone https://github.com/myc0576/smartmoney-cub-harness.git && cd smartmoney-cub-harness && pip install -e ".[dev]" && smcub loop --preset toy --agent-trigger "自进化"` |
 
+### 隔离安装与版本确认
+
+不要把开发版本直接装进全局 Python。Windows 推荐使用项目内虚拟环境：
+
+```powershell
+py -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -e ".[dev]"
+.\.venv\Scripts\smcub.exe --version
+.\.venv\Scripts\smcub.exe doctor
+```
+
+macOS / Linux：
+
+```bash
+python -m venv .venv
+./.venv/bin/python -m pip install -e ".[dev]"
+./.venv/bin/smcub --version
+./.venv/bin/smcub doctor
+```
+
+如果电脑里安装过多个 Python，直接输入 `smcub` 可能命中另一个环境中的旧版本。安装后请运行 `smcub --version` 和 `smcub doctor`；`doctor` 会以不暴露本地路径的方式提示启动器冲突。
+
+正式发布到 PyPI 后，普通 CLI 用户推荐使用 pipx，让命令拥有独立环境：
+
+```bash
+pipx install smartmoney-cub-harness
+pipx upgrade smartmoney-cub-harness
+```
+
+现有安装不会自动同步。Git editable、pip、pipx 和源码压缩包用户的升级方式，以及 SemVer、Git tag、GitHub Release、PyPI 发布顺序，见 [版本与升级政策](docs/versioning.md)。
+
 装好后最常用的安全命令：
 
 ```bash

--- a/docs/superpowers/plans/2026-07-15-cli-version-management.md
+++ b/docs/superpowers/plans/2026-07-15-cli-version-management.md
@@ -1,0 +1,521 @@
+# CLI Version Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prepare release `0.1.1` with a single version source, reliable CLI version reporting, privacy-safe launcher conflict diagnostics, and documented pipx/PyPI upgrade practices.
+
+**Architecture:** Keep the version as a literal package attribute and let setuptools read it dynamically for build metadata. Add a focused launcher-diagnostics module that returns path-free booleans and counts to `doctor`, while argparse owns the top-level version flag. Keep installation and release policy in documentation; do not add network checks or self-update behavior.
+
+**Tech Stack:** Python 3.10+, argparse, pathlib, sysconfig, setuptools PEP 621 metadata, pytest, Markdown, GitHub Actions.
+
+## Global Constraints
+
+- Preserve `READ_ONLY_NO_ORDER_NO_CANCEL_NO_TRADE` on every existing protected output.
+- Keep default operation offline with no telemetry, upload, update check, broker integration, or self-update mutation.
+- Add no runtime or development dependencies.
+- Never emit launcher paths, Python installation paths, usernames, credentials, or local identifiers.
+- Prepare version `0.1.1`; do not claim or perform a PyPI release before Trusted Publishing is configured and verified.
+- Use Semantic Versioning and never reuse a published version.
+
+---
+
+### Task 1: Single Version Source and `--version`
+
+**Files:**
+- Create: `tests/test_cli_version.py`
+- Modify: `src/smartmoney_cub_harness/__init__.py`
+- Modify: `src/smartmoney_cub_harness/cli.py`
+- Modify: `pyproject.toml`
+
+**Interfaces:**
+- Produces: `smartmoney_cub_harness.__version__: str` with value `0.1.1`.
+- Produces: `smcub --version` output `smcub 0.1.1` with exit code 0.
+- Produces: setuptools dynamic version mapping to `smartmoney_cub_harness.__version__`.
+
+- [ ] **Step 1: Write failing CLI and metadata tests**
+
+```python
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+from smartmoney_cub_harness import __version__
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cli_version_matches_package_version():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, "-m", "smartmoney_cub_harness.cli", "--version"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"smcub {__version__}"
+    assert __version__ == "0.1.1"
+
+
+def test_build_metadata_uses_package_version_attribute():
+    payload = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert payload["project"]["dynamic"] == ["version"]
+    assert "version" not in payload["project"]
+    assert payload["tool"]["setuptools"]["dynamic"]["version"] == {
+        "attr": "smartmoney_cub_harness.__version__"
+    }
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `python -m pytest tests/test_cli_version.py -v`
+
+Expected: FAIL because `--version` is not defined, the package version is `0.1.0`, and `pyproject.toml` still has a static version.
+
+- [ ] **Step 3: Implement the single source and CLI flag**
+
+Change `src/smartmoney_cub_harness/__init__.py`:
+
+```python
+__version__ = "0.1.1"
+```
+
+In `build_parser()` add before subparser creation:
+
+```python
+parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+```
+
+In `pyproject.toml`, replace the static version with:
+
+```toml
+[project]
+dynamic = ["version"]
+```
+
+and add:
+
+```toml
+[tool.setuptools.dynamic]
+version = { attr = "smartmoney_cub_harness.__version__" }
+```
+
+- [ ] **Step 4: Run focused and packaging tests and verify GREEN**
+
+Run: `python -m pytest tests/test_cli_version.py tests/test_doctor.py -v`
+
+Expected: all selected tests PASS.
+
+Run: `python -m pip wheel . --no-deps --wheel-dir tmp/version-wheel`
+
+Expected: exit 0 and a wheel named `smartmoney_cub_harness-0.1.1-*.whl`.
+
+- [ ] **Step 5: Commit the independently working version feature**
+
+```text
+git add pyproject.toml src/smartmoney_cub_harness/__init__.py src/smartmoney_cub_harness/cli.py tests/test_cli_version.py
+git commit -m "Make installed CLI versions unambiguous"
+```
+
+The actual commit must include the repository Lore trailers and record focused tests plus wheel build evidence.
+
+---
+
+### Task 2: Privacy-Safe Launcher Diagnostics
+
+**Files:**
+- Create: `src/smartmoney_cub_harness/launcher.py`
+- Create: `tests/test_launcher.py`
+- Modify: `src/smartmoney_cub_harness/cli.py`
+- Modify: `tests/test_doctor.py`
+
+**Interfaces:**
+- Produces: `launcher_diagnostics(path_value: str | None = None, scripts_dir: str | Path | None = None, platform_name: str | None = None, pathext: str | None = None) -> dict[str, bool | int]`.
+- Returns keys: `launcher_found`, `launcher_count`, `multiple_launchers`, `resolved_to_current_environment`.
+- `doctor()` adds the result under `launcher` without changing existing keys.
+
+- [ ] **Step 1: Write failing discovery and privacy tests**
+
+```python
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from smartmoney_cub_harness.launcher import launcher_diagnostics
+
+
+def _make_launcher(directory: Path, name: str = "smcub.exe") -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    launcher = directory / name
+    launcher.write_text("fixture", encoding="utf-8")
+    return launcher
+
+
+def test_launcher_diagnostics_reports_missing_launcher(tmp_path):
+    result = launcher_diagnostics(
+        path_value=str(tmp_path / "missing"),
+        scripts_dir=tmp_path / "current",
+        platform_name="nt",
+        pathext=".EXE;.CMD",
+    )
+
+    assert result == {
+        "launcher_found": False,
+        "launcher_count": 0,
+        "multiple_launchers": False,
+        "resolved_to_current_environment": False,
+    }
+
+
+def test_launcher_diagnostics_deduplicates_path_entries(tmp_path):
+    scripts = tmp_path / "current"
+    _make_launcher(scripts)
+    result = launcher_diagnostics(
+        path_value=os.pathsep.join([str(scripts), str(scripts)]),
+        scripts_dir=scripts,
+        platform_name="nt",
+        pathext=".EXE;.CMD",
+    )
+
+    assert result["launcher_count"] == 1
+    assert result["multiple_launchers"] is False
+    assert result["resolved_to_current_environment"] is True
+
+
+def test_launcher_diagnostics_detects_conflicting_launchers_without_paths(tmp_path):
+    stale = tmp_path / "stale"
+    current = tmp_path / "current"
+    _make_launcher(stale)
+    _make_launcher(current)
+    result = launcher_diagnostics(
+        path_value=os.pathsep.join([str(stale), str(current)]),
+        scripts_dir=current,
+        platform_name="nt",
+        pathext=".EXE;.CMD",
+    )
+
+    assert result == {
+        "launcher_found": True,
+        "launcher_count": 2,
+        "multiple_launchers": True,
+        "resolved_to_current_environment": False,
+    }
+    rendered = json.dumps(result)
+    assert str(stale) not in rendered
+    assert str(current) not in rendered
+```
+
+Extend `tests/test_doctor.py`:
+
+```python
+def test_doctor_includes_path_free_launcher_diagnostics():
+    result = doctor()
+
+    assert set(result["launcher"]) == {
+        "launcher_found",
+        "launcher_count",
+        "multiple_launchers",
+        "resolved_to_current_environment",
+    }
+    assert all(not isinstance(value, str) for value in result["launcher"].values())
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `python -m pytest tests/test_launcher.py tests/test_doctor.py -v`
+
+Expected: collection FAIL because `smartmoney_cub_harness.launcher` does not exist.
+
+- [ ] **Step 3: Implement deterministic launcher discovery**
+
+Create `src/smartmoney_cub_harness/launcher.py` with:
+
+```python
+from __future__ import annotations
+
+import os
+import sysconfig
+from pathlib import Path
+
+
+def launcher_diagnostics(
+    path_value: str | None = None,
+    scripts_dir: str | Path | None = None,
+    platform_name: str | None = None,
+    pathext: str | None = None,
+) -> dict[str, bool | int]:
+    path_value = os.environ.get("PATH", "") if path_value is None else path_value
+    scripts_path = Path(sysconfig.get_path("scripts") if scripts_dir is None else scripts_dir)
+    platform_name = os.name if platform_name is None else platform_name
+    if platform_name == "nt":
+        raw_extensions = os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD") if pathext is None else pathext
+        names = [f"smcub{extension.lower()}" for extension in raw_extensions.split(";") if extension]
+    else:
+        names = ["smcub"]
+
+    launchers: list[Path] = []
+    seen: set[str] = set()
+    for entry in path_value.split(os.pathsep):
+        if not entry:
+            continue
+        for name in names:
+            candidate = Path(entry) / name
+            if not candidate.is_file():
+                continue
+            identity = os.path.normcase(str(candidate.resolve()))
+            if identity not in seen:
+                seen.add(identity)
+                launchers.append(candidate)
+
+    current_scripts = os.path.normcase(str(scripts_path.resolve()))
+    first_is_current = bool(launchers) and os.path.normcase(str(launchers[0].parent.resolve())) == current_scripts
+    return {
+        "launcher_found": bool(launchers),
+        "launcher_count": len(launchers),
+        "multiple_launchers": len(launchers) > 1,
+        "resolved_to_current_environment": first_is_current,
+    }
+```
+
+Import `launcher_diagnostics` in `cli.py` and add:
+
+```python
+"launcher": launcher_diagnostics(),
+```
+
+to the doctor payload.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run: `python -m pytest tests/test_launcher.py tests/test_doctor.py -v`
+
+Expected: all selected tests PASS.
+
+Run: `python -m smartmoney_cub_harness.cli doctor`
+
+Expected: exit 0, existing safety fields remain present, and `launcher` contains only booleans and an integer.
+
+- [ ] **Step 5: Commit the independently working diagnostic feature**
+
+```text
+git add src/smartmoney_cub_harness/launcher.py src/smartmoney_cub_harness/cli.py tests/test_launcher.py tests/test_doctor.py
+git commit -m "Expose safe CLI launcher conflict diagnostics"
+```
+
+The actual commit must include Lore trailers and focused verification evidence.
+
+---
+
+### Task 3: Installation, Upgrade, and Release Documentation
+
+**Files:**
+- Create: `docs/versioning.md`
+- Modify: `.gitignore`
+- Modify: `README.md`
+- Modify: `README.zh-CN.md`
+- Modify: `tests/test_readme_commands.py`
+
+**Interfaces:**
+- Produces: documented Windows and POSIX isolated installation commands.
+- Produces: pipx as the preferred post-PyPI end-user installation and upgrade path.
+- Produces: explicit upgrade behavior for editable Git, pip, pipx, and copied source.
+
+- [ ] **Step 1: Write failing documentation contract tests**
+
+Extend `tests/test_readme_commands.py`:
+
+```python
+def test_readmes_document_isolated_installation_and_cli_upgrades():
+    readmes = [
+        (REPO_ROOT / "README.md").read_text(encoding="utf-8"),
+        (REPO_ROOT / "README.zh-CN.md").read_text(encoding="utf-8"),
+    ]
+
+    for readme in readmes:
+        assert "python -m venv .venv" in readme
+        assert "py -m venv .venv" in readme
+        assert "pipx install smartmoney-cub-harness" in readme
+        assert "pipx upgrade smartmoney-cub-harness" in readme
+        assert "smcub --version" in readme
+        assert "docs/versioning.md" in readme
+
+
+def test_versioning_policy_covers_all_supported_update_paths():
+    policy = (REPO_ROOT / "docs" / "versioning.md").read_text(encoding="utf-8")
+
+    assert "Semantic Versioning" in policy
+    assert "git pull" in policy
+    assert "python -m pip install --upgrade smartmoney-cub-harness" in policy
+    assert "pipx upgrade smartmoney-cub-harness" in policy
+    assert "Trusted Publishing" in policy
+    assert "vX.Y.Z" in policy
+    assert "does not update automatically" in policy
+
+
+def test_local_virtual_environment_is_ignored():
+    gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+
+    assert ".venv/" in gitignore
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `python -m pytest tests/test_readme_commands.py -v`
+
+Expected: FAIL because the new commands, policy file, and `.venv/` ignore rule do not exist.
+
+- [ ] **Step 3: Add exact installation and upgrade documentation**
+
+Add `.venv/` to `.gitignore`.
+
+Update both README files with:
+
+```text
+Windows repository setup:
+py -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -e ".[dev]"
+.\.venv\Scripts\smcub.exe --version
+
+POSIX repository setup:
+python -m venv .venv
+./.venv/bin/python -m pip install -e ".[dev]"
+./.venv/bin/smcub --version
+
+Preferred end-user setup after PyPI publication:
+pipx install smartmoney-cub-harness
+pipx upgrade smartmoney-cub-harness
+```
+
+State that a global `smcub` may resolve to a different Python environment, and recommend `smcub doctor` plus `smcub --version` after installation. Link `docs/versioning.md`.
+
+Create `docs/versioning.md` covering:
+
+- SemVer meanings and `0.1.1` as the current prepared patch release;
+- exact Git, pip, pipx, and copied-source upgrade commands;
+- the sentence `Existing installations do not update automatically.`;
+- `vX.Y.Z` tag, GitHub Release, PyPI Trusted Publishing, and clean pipx verification order;
+- prohibition on reusing versions, embedded credentials, background update checks, and self-update mutation.
+
+- [ ] **Step 4: Run documentation tests and verify GREEN**
+
+Run: `python -m pytest tests/test_readme_commands.py -v`
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 5: Commit the independently reviewable documentation**
+
+```text
+git add .gitignore README.md README.zh-CN.md docs/versioning.md tests/test_readme_commands.py
+git commit -m "Give CLI users a reliable upgrade path"
+```
+
+The actual commit must include Lore trailers and the documentation test evidence.
+
+---
+
+### Task 4: Full Release Readiness Verification
+
+**Files:**
+- Verify only; modify earlier files only if a failing check exposes an in-scope defect.
+
+**Interfaces:**
+- Consumes: `__version__ == "0.1.1"`, `launcher_diagnostics(...)`, updated READMEs, and `docs/versioning.md`.
+- Produces: fresh evidence that source tests, wheel metadata, doctor, privacy audit, and toy loop all satisfy the design.
+
+- [ ] **Step 1: Run static diff and repository checks**
+
+Run: `git diff main...HEAD --check`
+
+Expected: exit 0 with no whitespace errors.
+
+Run: `git status -sb`
+
+Expected: only the intended branch and no unstaged source changes before final verification.
+
+- [ ] **Step 2: Run the complete test suite**
+
+Run: `python -m pytest -q`
+
+Expected: exit 0 with all tests passing.
+
+- [ ] **Step 3: Build and inspect the wheel**
+
+Run: `python -m pip wheel . --no-deps --wheel-dir tmp/release-wheel`
+
+Expected: exit 0 and a `smartmoney_cub_harness-0.1.1-*.whl` artifact.
+
+- [ ] **Step 4: Verify installed CLI behavior through the current interpreter**
+
+Run: `python -m smartmoney_cub_harness.cli --version`
+
+Expected: exactly `smcub 0.1.1`.
+
+Run: `python -m smartmoney_cub_harness.cli doctor`
+
+Expected: JSON contains `version: 0.1.1`, launcher diagnostics, no exposed paths after redaction, and `READ_ONLY_NO_ORDER_NO_CANCEL_NO_TRADE`.
+
+Run: `python -m smartmoney_cub_harness.cli privacy-audit`
+
+Expected: network, telemetry, and upload are false and the safety declaration is present.
+
+Run: `python -m smartmoney_cub_harness.cli loop --preset toy --agent-trigger "自进化"`
+
+Expected: status is ok, `champion_mutated` is false, network and telemetry are false, and the safety declaration is present.
+
+- [ ] **Step 5: Inspect the final diff and commit any verification-only correction**
+
+Run: `git diff main...HEAD --stat` and `git diff main...HEAD`.
+
+Expected: changes are limited to the design, plan, version source, CLI diagnostics, tests, ignore rule, and version documentation. If verification required a correction, commit only the affected files with Lore trailers and repeat Steps 1–4.
+
+---
+
+### Task 5: Publish the Reviewed Branch
+
+**Files:**
+- No source modifications expected.
+
+**Interfaces:**
+- Consumes: clean verified branch `codex/cli-version-management`.
+- Produces: pushed remote branch and draft pull request targeting `main`.
+
+- [ ] **Step 1: Confirm authentication and scope**
+
+Run: `gh --version`, `gh auth status`, `git status -sb`, and `git diff main...HEAD --stat`.
+
+Expected: GitHub CLI is installed and authenticated, the worktree is clean, and only intended changes are present.
+
+- [ ] **Step 2: Push the branch**
+
+Run: `git push -u origin codex/cli-version-management`.
+
+Expected: exit 0 and upstream tracking configured.
+
+- [ ] **Step 3: Open a draft pull request**
+
+Use the connected GitHub app with:
+
+```text
+repository: myc0576/smartmoney-cub-harness
+base: main
+head: codex/cli-version-management
+title: Make CLI versions and upgrades predictable
+draft: true
+```
+
+The PR body must summarize the single version source, `--version`, privacy-safe doctor diagnostics, pipx/PyPI lifecycle, root cause of the PATH conflict, and exact verification evidence.
+
+- [ ] **Step 4: Report the handoff**
+
+Report branch, commit list, PR URL, full test count, wheel version, manual CLI checks, and the remaining external step: configuring PyPI Trusted Publishing before the first PyPI publication.

--- a/docs/superpowers/specs/2026-07-15-cli-version-management-design.md
+++ b/docs/superpowers/specs/2026-07-15-cli-version-management-design.md
@@ -1,0 +1,124 @@
+# CLI Version Management Design
+
+## Goal
+
+Make `smartmoney-cub-harness` a predictable, upgradeable CLI without weakening its offline-first and read-only safety boundaries. Users must be able to identify the installed version, diagnose conflicting launchers, and follow an explicit upgrade path.
+
+## Scope
+
+This change prepares release `0.1.1` and covers:
+
+- one authoritative package version;
+- a top-level `smcub --version` command;
+- launcher conflict diagnostics in `smcub doctor`;
+- isolated installation instructions for Windows and POSIX systems;
+- a documented SemVer, Git tag, GitHub Release, and PyPI/pipx lifecycle;
+- upgrade instructions for existing Git, pip, pipx, and copied-source users.
+
+Publishing to PyPI is a separate release operation because it requires repository and PyPI Trusted Publishing configuration. This change may document and prepare that workflow, but it must not introduce credentials or claim that a PyPI release exists before one is verified.
+
+## Version Source
+
+The package version will have one source of truth. `pyproject.toml` will obtain the build version from the package version attribute through setuptools dynamic metadata. Runtime output, built distributions, `smcub --version`, and `smcub doctor` will therefore report the same value.
+
+The release prepared by this change is `0.1.1`, a patch release because it improves packaging, diagnostics, and documentation without changing the decision-review contract.
+
+## CLI Behavior
+
+### `smcub --version`
+
+The root argument parser will support:
+
+```text
+smcub --version
+```
+
+It will print a stable, script-friendly line containing the command name and version, then exit successfully without running a subcommand or using the network.
+
+### `smcub doctor`
+
+The existing doctor payload will retain every current safety and privacy field. It will add a launcher diagnostic object containing only non-sensitive values:
+
+- whether an `smcub` launcher is discoverable on `PATH`;
+- how many distinct launchers are discoverable;
+- whether multiple launchers create a conflict risk;
+- whether the first launcher resolves to the current Python environment.
+
+Doctor must not print launcher paths, Python installation paths, usernames, credentials, or other local identifiers. The existing redaction layer remains in force.
+
+Launcher discovery will be deterministic and independently testable by accepting explicit PATH and platform inputs in a private helper. Duplicate path entries will not inflate the count. Missing launchers will be reported as a valid diagnostic state rather than a doctor failure.
+
+## Installation and Upgrade Model
+
+The preferred end-user installation will be `pipx` once the package is published to PyPI:
+
+```text
+pipx install smartmoney-cub-harness
+pipx upgrade smartmoney-cub-harness
+```
+
+Repository contributors and pre-PyPI users will use an isolated `.venv`. Documentation will avoid relying on an arbitrary global `smcub` executable during setup and will show module-based or environment-qualified commands where appropriate.
+
+Existing users do not update automatically:
+
+- editable Git checkout: `git pull`; reinstall only when packaging metadata or dependencies change;
+- pip installation: `python -m pip install --upgrade smartmoney-cub-harness`;
+- pipx installation: `pipx upgrade smartmoney-cub-harness`;
+- copied source archive: download a new release or migrate to Git/pipx.
+
+There will be no background update check and no `self-update` command. Both would add network behavior or mutate the user's Python environment, contrary to the project's default operating model.
+
+## Release Policy
+
+Versions follow Semantic Versioning:
+
+- patch: compatible fixes, documentation, diagnostics;
+- minor: compatible CLI commands or schema capabilities;
+- major: incompatible CLI, artifact, or contract changes.
+
+Each public release should follow this order:
+
+1. update the single version source;
+2. run the full test and doctor checks;
+3. merge the reviewed change;
+4. create a matching `vX.Y.Z` Git tag;
+5. create a GitHub Release from that tag;
+6. publish the same version to PyPI through Trusted Publishing;
+7. verify installation in a clean pipx environment.
+
+A version must never be reused after publication. Safety contract changes require explicit release notes even when backward compatible.
+
+## Tests
+
+Implementation will use test-driven development.
+
+Automated coverage will prove:
+
+- `smcub --version` succeeds and reports `0.1.1`;
+- runtime and build metadata use the same version source;
+- doctor preserves all existing safety fields;
+- doctor detects zero, one, duplicate, and multiple launcher cases;
+- doctor never exposes the supplied launcher paths;
+- both README files contain the supported install and upgrade commands;
+- the full existing test suite remains green.
+
+Manual verification will run the installed CLI from an isolated environment, execute `doctor`, execute the toy loop, and confirm `READ_ONLY_NO_ORDER_NO_CANCEL_NO_TRADE` and `champion_mutated=false` remain present.
+
+## Non-Goals
+
+- automatic background update checks;
+- self-modifying or self-updating CLI behavior;
+- broker, account, order, or cancellation integration;
+- storing credentials for PyPI or GitHub;
+- changing the review loop, rule governance, or safety declaration;
+- publishing to PyPI before Trusted Publishing is configured and verified.
+
+## Acceptance Criteria
+
+- Version `0.1.1` has exactly one source of truth.
+- `smcub --version` works without a subcommand.
+- `smcub doctor` reports launcher conflict risk without revealing local paths.
+- `.venv/` is ignored.
+- Windows, POSIX, pipx, and existing-user upgrade instructions are documented.
+- All tests pass on the supported Python versions through CI.
+- The toy loop remains offline and does not mutate champion rules.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,84 @@
+# Versioning and Upgrades
+
+`smartmoney-cub-harness` uses Semantic Versioning for its CLI, Python package, and portable artifact contracts.
+
+## Version meanings
+
+- Patch (`0.1.0` -> `0.1.1`): compatible fixes, packaging improvements, diagnostics, and documentation.
+- Minor (`0.1.x` -> `0.2.0`): backward-compatible CLI commands, schemas, or review capabilities.
+- Major (`0.x` -> `1.0.0`, then `1.x` -> `2.0.0`): incompatible CLI, artifact, schema, or safety-contract changes.
+
+Release `0.1.1` is prepared as a patch release. A published version is immutable and must never be reused.
+
+## Existing users
+
+An existing installation does not update automatically. Choose the command that matches the original installation method.
+
+### Editable Git checkout
+
+```bash
+git pull --ff-only
+python -m pip install -e ".[dev]"
+smcub --version
+```
+
+An editable installation normally sees source changes immediately after `git pull`. Reinstall after packaging metadata, entry points, or dependencies change. Release `0.1.1` changes packaging metadata, so reinstall it once.
+
+### pip installation
+
+After the package is published to PyPI:
+
+```bash
+python -m pip install --upgrade smartmoney-cub-harness
+smcub --version
+```
+
+### pipx installation
+
+pipx is the preferred end-user CLI installation because it isolates the command from unrelated Python environments:
+
+```bash
+pipx install smartmoney-cub-harness
+pipx upgrade smartmoney-cub-harness
+smcub --version
+smcub doctor
+```
+
+### Copied source or downloaded archive
+
+A copied directory or downloaded source archive has no update channel. Download a newer GitHub Release or migrate to a Git checkout or pipx installation.
+
+## PATH conflicts
+
+Multiple Python installations can each provide an executable named `smcub`. The shell runs the first match on `PATH`, which may be an older installation.
+
+Run both commands after installation or upgrade:
+
+```bash
+smcub --version
+smcub doctor
+```
+
+`doctor` reports whether multiple launchers exist and whether the first one belongs to the current Python environment. It reports only counts and booleans; it does not expose local installation paths.
+
+## Release lifecycle
+
+Every public release follows the same order:
+
+1. Update the single package version source.
+2. Run the full test suite, wheel build, doctor, privacy audit, and offline toy loop.
+3. Merge the reviewed change into `main`.
+4. Create an annotated `vX.Y.Z` Git tag for the merged commit.
+5. Create a GitHub Release from the same tag and describe user-visible changes and safety-contract impact.
+6. Publish the matching wheel and source distribution to PyPI through Trusted Publishing.
+7. Install or upgrade the release in a clean pipx environment and verify `smcub --version`, `smcub doctor`, and the toy loop.
+
+The Git tag, GitHub Release, Python package metadata, and PyPI version must match exactly.
+
+## PyPI publication boundary
+
+The repository must use PyPI Trusted Publishing rather than storing a long-lived PyPI token. Publication must not begin until the PyPI project and its GitHub repository/environment trust relationship are configured and verified.
+
+This CLI does not perform background update checks and does not modify its own Python environment. It remains offline by default with no telemetry or upload. Users initiate upgrades explicitly with Git, pip, or pipx.
+
+`READ_ONLY_NO_ORDER_NO_CANCEL_NO_TRADE`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "smartmoney-cub-harness"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A read-only trading companion harness for decision logging, outcome review, and rule evolution."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -48,6 +48,9 @@ smcub = "smartmoney_cub_harness.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.dynamic]
+version = { attr = "smartmoney_cub_harness.__version__" }
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/smartmoney_cub_harness/__init__.py
+++ b/src/smartmoney_cub_harness/__init__.py
@@ -2,6 +2,6 @@ from __future__ import annotations
 
 from smartmoney_cub_harness.schemas import SAFETY_DECLARATION
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = ["SAFETY_DECLARATION", "__version__"]

--- a/src/smartmoney_cub_harness/cli.py
+++ b/src/smartmoney_cub_harness/cli.py
@@ -100,6 +100,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="smcub",
         description="Read-only trading companion harness for decision logging, outcome review, and rule evolution.",
     )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     sub = parser.add_subparsers(dest="command", required=True)
 
     validate = sub.add_parser("validate-manifest", help="Validate a run manifest JSON file")

--- a/src/smartmoney_cub_harness/cli.py
+++ b/src/smartmoney_cub_harness/cli.py
@@ -11,6 +11,7 @@ from smartmoney_cub_harness import __version__
 from smartmoney_cub_harness.case_bank import collect_offline_case
 from smartmoney_cub_harness.evaluator import evaluate_decision
 from smartmoney_cub_harness.evolution_ledger import append_ledger_event
+from smartmoney_cub_harness.launcher import launcher_diagnostics
 from smartmoney_cub_harness.loop import run_agent_loop
 from smartmoney_cub_harness.manifest import validate_run_manifest
 from smartmoney_cub_harness.memory import save_memory_record
@@ -91,6 +92,7 @@ def doctor() -> dict[str, Any]:
         "broker_api_required": False,
         "execution_integrations": "disabled",
         "default_data_mode": "offline_json_fixtures",
+        "launcher": launcher_diagnostics(),
         "safety": SAFETY_DECLARATION,
     }
 

--- a/src/smartmoney_cub_harness/launcher.py
+++ b/src/smartmoney_cub_harness/launcher.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import sysconfig
+from pathlib import Path
+
+
+def launcher_diagnostics(
+    path_value: str | None = None,
+    scripts_dir: str | Path | None = None,
+    platform_name: str | None = None,
+    pathext: str | None = None,
+) -> dict[str, bool | int]:
+    path_value = os.environ.get("PATH", "") if path_value is None else path_value
+    scripts_path = Path(sysconfig.get_path("scripts") if scripts_dir is None else scripts_dir)
+    platform_name = os.name if platform_name is None else platform_name
+    if platform_name == "nt":
+        raw_extensions = os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD") if pathext is None else pathext
+        names = [f"smcub{extension.lower()}" for extension in raw_extensions.split(";") if extension]
+    else:
+        names = ["smcub"]
+
+    launchers: list[Path] = []
+    seen: set[str] = set()
+    for entry in path_value.split(os.pathsep):
+        if not entry:
+            continue
+        for name in names:
+            candidate = Path(entry) / name
+            if not candidate.is_file():
+                continue
+            identity = os.path.normcase(str(candidate.resolve()))
+            if identity not in seen:
+                seen.add(identity)
+                launchers.append(candidate)
+
+    current_scripts = os.path.normcase(str(scripts_path.resolve()))
+    first_is_current = bool(launchers) and os.path.normcase(str(launchers[0].parent.resolve())) == current_scripts
+    return {
+        "launcher_found": bool(launchers),
+        "launcher_count": len(launchers),
+        "multiple_launchers": len(launchers) > 1,
+        "resolved_to_current_environment": first_is_current,
+    }

--- a/src/smartmoney_cub_harness/private_input.py
+++ b/src/smartmoney_cub_harness/private_input.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from smartmoney_cub_harness.manifest import parse_timestamp
-from smartmoney_cub_harness.safety import redact
+from smartmoney_cub_harness.safety import REDACTED, redact
 from smartmoney_cub_harness.schemas import (
     DECISION_SCHEMA,
     OUTCOME_SCHEMA,
@@ -46,7 +46,7 @@ def fingerprint_file(path: str | Path) -> dict[str, Any]:
     stat = input_path.stat()
     return redact(
         {
-            "path": str(input_path),
+            "path": REDACTED,
             "name": input_path.name,
             "sha256": digest.hexdigest(),
             "bytes": stat.st_size,

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+from smartmoney_cub_harness import __version__
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cli_version_matches_package_version():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT / "src") + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run(
+        [sys.executable, "-m", "smartmoney_cub_harness.cli", "--version"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"smcub {__version__}"
+    assert __version__ == "0.1.1"
+
+
+def test_build_metadata_uses_package_version_attribute():
+    payload = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert payload["project"]["dynamic"] == ["version"]
+    assert "version" not in payload["project"]
+    assert payload["tool"]["setuptools"]["dynamic"]["version"] == {
+        "attr": "smartmoney_cub_harness.__version__"
+    }

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
-import tomllib
 from pathlib import Path
 
 from smartmoney_cub_harness import __version__
@@ -29,10 +29,9 @@ def test_cli_version_matches_package_version():
 
 
 def test_build_metadata_uses_package_version_attribute():
-    payload = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    payload = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
 
-    assert payload["project"]["dynamic"] == ["version"]
-    assert "version" not in payload["project"]
-    assert payload["tool"]["setuptools"]["dynamic"]["version"] == {
-        "attr": "smartmoney_cub_harness.__version__"
-    }
+    assert 'dynamic = ["version"]' in payload
+    assert re.search(r"(?m)^version\s*=\s*['\"]", payload) is None
+    assert '[tool.setuptools.dynamic]' in payload
+    assert 'version = { attr = "smartmoney_cub_harness.__version__" }' in payload

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -16,3 +16,15 @@ def test_doctor_reports_offline_no_credentials_required():
     assert result["broker_api_required"] is False
     assert result["execution_integrations"] == "disabled"
     assert result["safety"] == SAFETY_DECLARATION
+
+
+def test_doctor_includes_path_free_launcher_diagnostics():
+    result = doctor()
+
+    assert set(result["launcher"]) == {
+        "launcher_found",
+        "launcher_count",
+        "multiple_launchers",
+        "resolved_to_current_environment",
+    }
+    assert all(not isinstance(value, str) for value in result["launcher"].values())

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from smartmoney_cub_harness.launcher import launcher_diagnostics
+
+
+def _make_launcher(directory: Path, name: str = "smcub.exe") -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    launcher = directory / name
+    launcher.write_text("fixture", encoding="utf-8")
+    return launcher
+
+
+def test_launcher_diagnostics_reports_missing_launcher(tmp_path):
+    result = launcher_diagnostics(
+        path_value=str(tmp_path / "missing"),
+        scripts_dir=tmp_path / "current",
+        platform_name="nt",
+        pathext=".EXE;.CMD",
+    )
+
+    assert result == {
+        "launcher_found": False,
+        "launcher_count": 0,
+        "multiple_launchers": False,
+        "resolved_to_current_environment": False,
+    }
+
+
+def test_launcher_diagnostics_deduplicates_path_entries(tmp_path):
+    scripts = tmp_path / "current"
+    _make_launcher(scripts)
+    result = launcher_diagnostics(
+        path_value=os.pathsep.join([str(scripts), str(scripts)]),
+        scripts_dir=scripts,
+        platform_name="nt",
+        pathext=".EXE;.CMD",
+    )
+
+    assert result["launcher_count"] == 1
+    assert result["multiple_launchers"] is False
+    assert result["resolved_to_current_environment"] is True
+
+
+def test_launcher_diagnostics_detects_conflicting_launchers_without_paths(tmp_path):
+    stale = tmp_path / "stale"
+    current = tmp_path / "current"
+    _make_launcher(stale)
+    _make_launcher(current)
+    result = launcher_diagnostics(
+        path_value=os.pathsep.join([str(stale), str(current)]),
+        scripts_dir=current,
+        platform_name="nt",
+        pathext=".EXE;.CMD",
+    )
+
+    assert result == {
+        "launcher_found": True,
+        "launcher_count": 2,
+        "multiple_launchers": True,
+        "resolved_to_current_environment": False,
+    }
+    rendered = json.dumps(result)
+    assert str(stale) not in rendered
+    assert str(current) not in rendered

--- a/tests/test_private_input.py
+++ b/tests/test_private_input.py
@@ -4,6 +4,7 @@ import csv
 from pathlib import Path
 
 from smartmoney_cub_harness.private_input import REQUIRED_PRIVATE_CASE_FIELDS, fingerprint_file, load_private_cases
+from smartmoney_cub_harness.safety import REDACTED
 from smartmoney_cub_harness.schemas import SAFETY_DECLARATION
 
 
@@ -99,4 +100,5 @@ def test_fingerprint_redacts_private_local_path(tmp_path: Path):
 
     assert result["safety"] == SAFETY_DECLARATION
     assert result["sha256"]
+    assert result["path"] == REDACTED
     assert str(csv_path) not in str(result)

--- a/tests/test_readme_commands.py
+++ b/tests/test_readme_commands.py
@@ -53,3 +53,36 @@ def test_readme_points_to_integration_contract():
     assert "recommended-companion" in integrations
     assert "runtime-integrated" in integrations
     assert SAFETY_DECLARATION in integrations
+
+
+def test_readmes_document_isolated_installation_and_cli_upgrades():
+    readmes = [
+        (REPO_ROOT / "README.md").read_text(encoding="utf-8"),
+        (REPO_ROOT / "README.zh-CN.md").read_text(encoding="utf-8"),
+    ]
+
+    for readme in readmes:
+        assert "python -m venv .venv" in readme
+        assert "py -m venv .venv" in readme
+        assert "pipx install smartmoney-cub-harness" in readme
+        assert "pipx upgrade smartmoney-cub-harness" in readme
+        assert "smcub --version" in readme
+        assert "docs/versioning.md" in readme
+
+
+def test_versioning_policy_covers_all_supported_update_paths():
+    policy = (REPO_ROOT / "docs" / "versioning.md").read_text(encoding="utf-8")
+
+    assert "Semantic Versioning" in policy
+    assert "git pull" in policy
+    assert "python -m pip install --upgrade smartmoney-cub-harness" in policy
+    assert "pipx upgrade smartmoney-cub-harness" in policy
+    assert "Trusted Publishing" in policy
+    assert "vX.Y.Z" in policy
+    assert "does not update automatically" in policy.lower()
+
+
+def test_local_virtual_environment_is_ignored():
+    gitignore = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+
+    assert ".venv/" in gitignore

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_workflow_uses_tagged_trusted_publishing():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert 'tags: ["v*"]' in workflow
+    assert 'environment: pypi' in workflow
+    assert 'id-token: write' in workflow
+    assert 'pypa/gh-action-pypi-publish@release/v1' in workflow
+    assert 'PYPI_TOKEN' not in workflow
+    assert 'password:' not in workflow
+
+
+def test_release_workflow_validates_version_and_publishes_release_assets():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert 'Verify tag matches package version' in workflow
+    assert 'python -m build' in workflow
+    assert 'actions/upload-artifact@v4' in workflow
+    assert 'actions/download-artifact@v4' in workflow
+    assert 'needs: pypi-publish' in workflow
+    assert 'gh release create' in workflow
+    assert 'dist/*' in workflow


### PR DESCRIPTION
## What changed

- prepare patch release `0.1.1` with one authoritative version source
- add `smcub --version`
- add path-free launcher conflict diagnostics to `smcub doctor`
- document `.venv`, pipx, explicit upgrades, SemVer, GitHub Releases, and PyPI Trusted Publishing
- fix the existing POSIX privacy gap by making private-input fingerprint paths always `[REDACTED]`

## Root cause

Multiple Python environments can each install `smcub`, and the shell may resolve an older launcher first. The initial PR CI run also exposed an existing Linux-only privacy defect: Windows paths were redacted, while `/tmp/...` fingerprint paths were returned verbatim.

## Safety and user impact

There is no background update check or self-update mutation. The CLI remains offline by default, emits no local launcher or fingerprint paths, adds no dependencies, retains `READ_ONLY_NO_ORDER_NO_CANCEL_NO_TRADE`, and keeps `champion_mutated=false` in the toy loop.

## Verification

- local Python 3.12: 74 tests passed
- focused privacy/redaction: 7 tests passed
- compileall passed
- built `smartmoney_cub_harness-0.1.1-py3-none-any.whl`
- verified version, doctor, privacy audit, toy loop, and artifact inspection
- GitHub Actions run 21 passed on Python 3.10, 3.11, and 3.12
- every CI matrix job passed tests, doctor, English toy loop, and Chinese toy loop
