### PR TITLE
Release the CLI through GitHub without PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,27 +46,9 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-  pypi-publish:
-    name: Publish distributions to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download distributions
-        uses: actions/download-artifact@v4
-        with:
-          name: python-package-distributions
-          path: dist/
-
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
   github-release:
     name: Create GitHub Release
-    needs: pypi-publish
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ python -m venv .venv
 
 如果电脑里安装过多个 Python，直接输入 `smcub` 可能命中另一个环境中的旧版本。安装后请运行 `smcub --version` 和 `smcub doctor`；`doctor` 会以不暴露本地路径的方式提示启动器冲突。
 
-正式发布到 PyPI 后，普通 CLI 用户推荐使用 pipx，让命令拥有独立环境：
+当前发行渠道是 GitHub Releases。`v0.1.1` 发布后，普通 CLI 用户可用 pipx 从固定 tag 安装，让命令拥有独立环境：
+
+```bash
+pipx install "git+https://github.com/myc0576/smartmoney-cub-harness.git@v0.1.1"
+```
+
+未来正式发布到 PyPI 后，可改用更短的安装和升级命令：
 
 ```bash
 pipx install smartmoney-cub-harness

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,7 +70,13 @@ python -m venv .venv
 
 如果电脑里安装过多个 Python，直接输入 `smcub` 可能命中另一个环境中的旧版本。安装后请运行 `smcub --version` 和 `smcub doctor`；`doctor` 会以不暴露本地路径的方式提示启动器冲突。
 
-正式发布到 PyPI 后，普通 CLI 用户推荐使用 pipx，让命令拥有独立环境：
+当前发行渠道是 GitHub Releases。`v0.1.1` 发布后，普通 CLI 用户可用 pipx 从固定 tag 安装，让命令拥有独立环境：
+
+```bash
+pipx install "git+https://github.com/myc0576/smartmoney-cub-harness.git@v0.1.1"
+```
+
+未来正式发布到 PyPI 后，可改用更短的安装和升级命令：
 
 ```bash
 pipx install smartmoney-cub-harness

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -2,6 +2,8 @@
 
 `smartmoney-cub-harness` uses Semantic Versioning for its CLI, Python package, and portable artifact contracts.
 
+Current release channel: GitHub Releases. Each release provides a Git tag, wheel, and source distribution. PyPI publication is optional and deferred until a project owner configures Trusted Publishing.
+
 ## Version meanings
 
 - Patch (`0.1.0` -> `0.1.1`): compatible fixes, packaging improvements, diagnostics, and documentation.
@@ -35,7 +37,15 @@ smcub --version
 
 ### pipx installation
 
-pipx is the preferred end-user CLI installation because it isolates the command from unrelated Python environments:
+pipx is the preferred end-user CLI installation because it isolates the command from unrelated Python environments. Install the current GitHub tag directly:
+
+```bash
+pipx install "git+https://github.com/myc0576/smartmoney-cub-harness.git@v0.1.1"
+smcub --version
+smcub doctor
+```
+
+To move an existing pipx installation to a future GitHub tag, install that tag with `--force`. After a future PyPI publication, the shorter commands become available:
 
 ```bash
 pipx install smartmoney-cub-harness
@@ -70,14 +80,14 @@ Every public release follows the same order:
 3. Merge the reviewed change into `main`.
 4. Create an annotated `vX.Y.Z` Git tag for the merged commit.
 5. Create a GitHub Release from the same tag and describe user-visible changes and safety-contract impact.
-6. Publish the matching wheel and source distribution to PyPI through Trusted Publishing.
-7. Install or upgrade the release in a clean pipx environment and verify `smcub --version`, `smcub doctor`, and the toy loop.
+6. Attach the matching wheel and source distribution to the GitHub Release.
+7. Install the tag in a clean pipx environment and verify `smcub --version`, `smcub doctor`, and the toy loop.
 
-The Git tag, GitHub Release, Python package metadata, and PyPI version must match exactly.
+The Git tag, GitHub Release, and Python package metadata must match exactly. If PyPI is enabled later, its version must match them too.
 
 ## PyPI publication boundary
 
-The repository must use PyPI Trusted Publishing rather than storing a long-lived PyPI token. Publication must not begin until the PyPI project and its GitHub repository/environment trust relationship are configured and verified.
+PyPI is not required for the current GitHub Release channel. If it is enabled later, the repository must use PyPI Trusted Publishing rather than storing a long-lived PyPI token. Publication must not begin until the PyPI project and its GitHub repository/environment trust relationship are configured and verified.
 
 This CLI does not perform background update checks and does not modify its own Python environment. It remains offline by default with no telemetry or upload. Users initiate upgrades explicitly with Git, pip, or pipx.
 

--- a/tests/test_readme_commands.py
+++ b/tests/test_readme_commands.py
@@ -80,6 +80,8 @@ def test_versioning_policy_covers_all_supported_update_paths():
     assert "Trusted Publishing" in policy
     assert "vX.Y.Z" in policy
     assert "does not update automatically" in policy.lower()
+    assert "Current release channel: GitHub Releases" in policy
+    assert "git+https://github.com/myc0576/smartmoney-cub-harness.git@v0.1.1" in policy
 
 
 def test_local_virtual_environment_is_ignored():

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -5,13 +5,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_release_workflow_uses_tagged_trusted_publishing():
+def test_release_workflow_uses_tagged_github_releases_without_pypi():
     workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
 
     assert 'tags: ["v*"]' in workflow
-    assert 'environment: pypi' in workflow
-    assert 'id-token: write' in workflow
-    assert 'pypa/gh-action-pypi-publish@release/v1' in workflow
+    assert 'environment: pypi' not in workflow
+    assert 'id-token: write' not in workflow
+    assert 'pypa/gh-action-pypi-publish@release/v1' not in workflow
     assert 'PYPI_TOKEN' not in workflow
     assert 'password:' not in workflow
 
@@ -23,6 +23,6 @@ def test_release_workflow_validates_version_and_publishes_release_assets():
     assert 'python -m build' in workflow
     assert 'actions/upload-artifact@v4' in workflow
     assert 'actions/download-artifact@v4' in workflow
-    assert 'needs: pypi-publish' in workflow
+    assert 'needs: build' in workflow
     assert 'gh release create' in workflow
     assert 'dist/*' in workflow


### PR DESCRIPTION
## What changed

- make GitHub Releases the active `v0.1.1` distribution channel
- remove the unavailable PyPI publish job from the tag workflow
- attach wheel and sdist directly to the GitHub Release
- document pipx installation from the immutable Git tag
- retain PyPI Trusted Publishing as an optional future path

## Why

The project owner does not currently have a PyPI account. Pushing `v0.1.1` with the existing mandatory PyPI job would create a known-failing release. This keeps the CLI distributable now without credentials or a package index account.

## Verification

- 7 focused release/documentation contract tests passed
- 76 full tests passed
- compileall and diff checks passed
