### PR TITLE
Fix GitHub Release repository discovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,5 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: >-
           gh release create "${GITHUB_REF_NAME}" dist/*
+          --repo "${GITHUB_REPOSITORY}"
           --verify-tag --generate-notes --title "${GITHUB_REF_NAME}"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -25,4 +25,5 @@ def test_release_workflow_validates_version_and_publishes_release_assets():
     assert 'actions/download-artifact@v4' in workflow
     assert 'needs: build' in workflow
     assert 'gh release create' in workflow
+    assert '--repo "${GITHUB_REPOSITORY}"' in workflow
     assert 'dist/*' in workflow


### PR DESCRIPTION
## Summary

- pass the Actions repository explicitly to `gh release create`
- add regression coverage for checkout-free release jobs

## Why

The `v0.1.1` release build succeeded, but the release job ran outside a Git checkout and `gh` could not discover the repository.

## Verification

- `py -3.12 -m pytest tests/test_release_workflow.py -q` (2 passed)
- `py -3.12 -m pytest -q` (76 passed)